### PR TITLE
.NETStandard 2.1 and .NET 4.7.2 migration - switching over to new Sql…

### DIFF
--- a/DistributedLock.Tests/DistributedLock.Tests.csproj
+++ b/DistributedLock.Tests/DistributedLock.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Medallion.Threading.Tests</RootNamespace>
     <AssemblyName>DistributedLock.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -45,8 +45,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/DistributedLock.Tests/Tests/TestSetupTest.cs
+++ b/DistributedLock.Tests/Tests/TestSetupTest.cs
@@ -1,12 +1,9 @@
-﻿using Medallion.Collections;
+﻿//using Medallion.Collections;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Medallion.Threading.Tests
 {
@@ -74,7 +71,7 @@ namespace Medallion.Threading.Tests
         private List<Type[]> GetTypesForGenericParameters(Type[] genericParameters)
         {
             var genericParameterTypes = genericParameters.Select(this.GetTypesForGenericParameter).ToArray();
-            var allCombinations = Traverse.DepthFirst(
+            var allCombinations = Medallion.Collections.Traverse.DepthFirst(
                     root: (index: 0, value: Enumerable.Empty<Type>()),
                     children: t => t.index == genericParameterTypes.Length
                         ? Enumerable.Empty<(int index, IEnumerable<Type> value)>()

--- a/DistributedLock.Tests/packages.config
+++ b/DistributedLock.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="MedallionCollections" version="1.1.0" targetFramework="net46" />
   <package id="MedallionShell" version="1.2.1" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/DistributedLock/AssemblyAttributes.cs
+++ b/DistributedLock/AssemblyAttributes.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DistributedLock.Tests")]

--- a/DistributedLock/AwaitableDisposable.cs
+++ b/DistributedLock/AwaitableDisposable.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Medallion.Threading

--- a/DistributedLock/DeadlockException.cs
+++ b/DistributedLock/DeadlockException.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Medallion.Threading
 {
@@ -8,7 +6,7 @@ namespace Medallion.Threading
     /// An exception that SOME distributed locks will throw under SOME deadlock conditions. Note that even locks
     /// that throw this exception under some circumstances cannot detect ALL deadlock conditions
     /// </summary>
-#if !NETSTANDARD_1_3
+#if !NETSTANDARD_2_1
     [Serializable]
 #endif
     public sealed class DeadlockException 
@@ -30,7 +28,7 @@ namespace Medallion.Threading
         /// </summary>
         public DeadlockException(string message, Exception innerException) : base(message, innerException) { }
 
-#if !NETSTANDARD_1_3
+#if !NETSTANDARD_2_1
         private DeadlockException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
 #endif
     }

--- a/DistributedLock/DistributedLock.csproj
+++ b/DistributedLock/DistributedLock.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <RootNamespace>Medallion.Threading</RootNamespace>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Authors>Michael Adelson</Authors>
     <Description>Provides easy-to-use and robust fully distributed locks (using SQLServer) as well as wrappers for named system-wide locks (using WaitHandles)</Description>
     <Copyright>Copyright © 2017 Michael Adelson</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/madelson/DistributedLock/master/License.txt</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageTags>distributed lock async waithandle mutex sql sqlserver reader writer azure</PackageTags>
     <PackageProjectUrl>https://github.com/madelson/DistributedLock</PackageProjectUrl>
     <RepositoryUrl></RepositoryUrl>
@@ -24,7 +24,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <AssemblyVersion>1.5.0.0</AssemblyVersion>
+    <PackageLicenseExpression></PackageLicenseExpression>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -36,20 +38,28 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <DefineConstants>NETSTANDARD_1_3</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>NETSTANDARD_2_1</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+	<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\License.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 </Project>

--- a/DistributedLock/DistributedLockHelpers.cs
+++ b/DistributedLock/DistributedLockHelpers.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Text;

--- a/DistributedLock/IDistributedLock.cs
+++ b/DistributedLock/IDistributedLock.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/ReleaseAction.cs
+++ b/DistributedLock/ReleaseAction.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace Medallion.Threading

--- a/DistributedLock/Sql/ConnectionMultiplexing/MultiplexedConnectionLock.cs
+++ b/DistributedLock/Sql/ConnectionMultiplexing/MultiplexedConnectionLock.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
+using Microsoft.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/ConnectionMultiplexing/MultiplexedConnectionLockPool.cs
+++ b/DistributedLock/Sql/ConnectionMultiplexing/MultiplexedConnectionLockPool.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/IInternalSqlDistributedLock.cs
+++ b/DistributedLock/Sql/IInternalSqlDistributedLock.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/ISqlSynchronizationStrategy.cs
+++ b/DistributedLock/Sql/ISqlSynchronizationStrategy.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Medallion.Threading.Sql

--- a/DistributedLock/Sql/InternalLocks/AzureSqlDistributedLock.cs
+++ b/DistributedLock/Sql/InternalLocks/AzureSqlDistributedLock.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
+﻿using Microsoft.Data.SqlClient;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/InternalLocks/ExternalConnectionOrTransactionDistributedLock.cs
+++ b/DistributedLock/Sql/InternalLocks/ExternalConnectionOrTransactionDistributedLock.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/InternalLocks/OptimisticConnectionMultiplexingSqlDistributedLock.cs
+++ b/DistributedLock/Sql/InternalLocks/OptimisticConnectionMultiplexingSqlDistributedLock.cs
@@ -1,8 +1,5 @@
 ﻿using Medallion.Threading.Sql.ConnectionMultiplexing;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/InternalLocks/OwnedConnectionSqlDistributedLock.cs
+++ b/DistributedLock/Sql/InternalLocks/OwnedConnectionSqlDistributedLock.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
+﻿using Microsoft.Data.SqlClient;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/InternalLocks/OwnedTransactionSqlDistributedLock.cs
+++ b/DistributedLock/Sql/InternalLocks/OwnedTransactionSqlDistributedLock.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
+﻿using Microsoft.Data.SqlClient;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/KeepaliveHelper.cs
+++ b/DistributedLock/Sql/KeepaliveHelper.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/SqlApplicationLock.cs
+++ b/DistributedLock/Sql/SqlApplicationLock.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/SqlDistributedLock.cs
+++ b/DistributedLock/Sql/SqlDistributedLock.cs
@@ -1,12 +1,6 @@
-﻿using Medallion.Threading.Sql.ConnectionMultiplexing;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/SqlDistributedLockConnectionStrategy.cs
+++ b/DistributedLock/Sql/SqlDistributedLockConnectionStrategy.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.Data.SqlClient;
+using System;
 
 namespace Medallion.Threading.Sql
 {

--- a/DistributedLock/Sql/SqlDistributedReaderWriterLock.cs
+++ b/DistributedLock/Sql/SqlDistributedReaderWriterLock.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/SqlDistributedSemaphore.cs
+++ b/DistributedLock/Sql/SqlDistributedSemaphore.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/SqlHelpers.cs
+++ b/DistributedLock/Sql/SqlHelpers.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.Data.SqlClient;
+using System;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/Sql/SqlSemaphore.cs
+++ b/DistributedLock/Sql/SqlSemaphore.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.Data.SqlClient;
+using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Text;

--- a/DistributedLock/SystemDistributedLock.cs
+++ b/DistributedLock/SystemDistributedLock.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLock/WaitHandleHelpers.cs
+++ b/DistributedLock/WaitHandleHelpers.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DistributedLockTaker/App.config
+++ b/DistributedLockTaker/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/DistributedLockTaker/DistributedLockTaker.csproj
+++ b/DistributedLockTaker/DistributedLockTaker.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DistributedLockTaker</RootNamespace>
     <AssemblyName>DistributedLockTaker</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Hi,
I've made the following changes to meet my needs on a project developed with .NetCore 3.1:
1. projects migration to .NETStandard 2.1 and .NET 4.7.2
2. Switched over to new SqlClient package (related to issue: https://github.com/madelson/DistributedLock/issues/25#issue-445421722)



