### PR TITLE
Sample pull request with very basic support for acquiring locks on multiple resources in one call

### DIFF
--- a/DistributedLock.Tests/Tests/SqlDistributedLocksTest.cs
+++ b/DistributedLock.Tests/Tests/SqlDistributedLocksTest.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using Medallion.Threading.Sql;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+// ReSharper disable once CheckNamespace
+namespace Medallion.Threading.Tests.Sql
+{
+    public class SqlDistributedLocksTest
+    {
+        private const string ConnectionString = "Server=vm-pc-sql02;Database=NEU14270_200509_Seba;Trusted_Connection=True;";
+        private readonly SqlConnection conn;
+
+        public SqlDistributedLocksTest()
+        {
+            conn = new SqlConnection(ConnectionString);
+            conn.Open();
+        }
+
+        [Test]
+        public void TestBasicLocks()
+        {
+            using var tran = conn.BeginTransaction();
+            var locks = new SqlDistributedLocks(new [] {"LOCK1", "LOCK2"}, tran);
+            using var handle = locks.Acquire();
+        }
+
+        [Test]
+        public void TestBasicLocksOwnedConnection()
+        {
+            using var tran = conn.BeginTransaction();
+            var locks = new SqlDistributedLocks(new[] { "LOCK1", "LOCK2" }, ConnectionString);
+            using var handle = locks.Acquire();
+        }
+
+        [Test]
+        public void TestBasicLocksOwnedTransaction()
+        {
+            using var tran = conn.BeginTransaction();
+            var locks = new SqlDistributedLocks(new[] { "LOCK1", "LOCK2" }, ConnectionString, SqlDistributedLockConnectionStrategy.Transaction);
+            using var handle = locks.Acquire();
+        }
+
+        [Test]
+        public void TestFailAcquiringLocks()
+        {
+            using var tran = conn.BeginTransaction();
+            var locks = new SqlDistributedLocks(new[] { "LOCK1", "LOCK2" }, tran);
+            using var handle = locks.Acquire();
+
+            using var conn2 = new SqlConnection("Server=vm-pc-sql02;Database=NEU14270_200509_Seba;Trusted_Connection=True;");
+            conn2.Open();
+            using var tran2 = conn2.BeginTransaction();
+            var locks2 = new SqlDistributedLocks(new[] { "LOCK1", "LOCK3" }, tran2);
+            Assert.Throws<TimeoutException>(() =>
+            {
+                using var handle2 = locks2.Acquire(TimeSpan.Zero);
+            });
+            handle.Dispose();
+            using var lockListCmd = new SqlCommand(@"
+                SELECT l.*
+                FROM sys.dm_tran_locks l
+                WHERE resource_type = 'APPLICATION'", conn, tran);
+            using var reader = lockListCmd.ExecuteReader();
+            Assert.IsFalse(reader.HasRows, "There should be no locks");
+        }
+
+        [Test]
+        public void TestHighVolumeLocks()
+        {
+            using var tran = conn.BeginTransaction();
+            var lockNames = new List<string>();
+            for (var i = 0; i < 500; i++)
+                lockNames.Add($"LOCK{i}");
+            var locks = new SqlDistributedLocks(lockNames, tran);
+            using var handle = locks.Acquire();
+        }
+    }
+}

--- a/DistributedLock/Sql/IInternalSqlDistributedLocks.cs
+++ b/DistributedLock/Sql/IInternalSqlDistributedLocks.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Medallion.Threading.Sql
+{
+    /// <summary>
+    /// There are several strategies for implementing SQL-based locks; this interface
+    /// abstracts between them to keep the implementation of <see cref="SqlDistributedLock"/> manageable
+    /// </summary>
+    internal interface IInternalSqlDistributedLocks
+    {
+        // the contextHandle argument to these methods is used when acquiring a nested lock, such as upgrading
+        // from an upgradeable read lock to a write lock. This allows the implementation to use the same connection
+        // for the nested lock
+
+        IDisposable? TryAcquire<TLockCookie>(int timeoutMillis, ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, IDisposable? contextHandle) where TLockCookie : class;
+    }
+}

--- a/DistributedLock/Sql/ISqlSynchronizationStrategyMultiple.cs
+++ b/DistributedLock/Sql/ISqlSynchronizationStrategyMultiple.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace Medallion.Threading.Sql
+{
+    /// <summary>
+    /// Represents a "locking algorithm" implemented in SQL
+    /// </summary>
+    interface ISqlSynchronizationStrategyMultiple<TLockCookie>
+        where TLockCookie : class
+    {
+        /// <summary>
+        /// True iff the lock taken by the algorithm can be upgraded on the same connection (basically for upgradeable read locks).
+        /// 
+        /// We need this property because the multiplexing approach has to avoid multiplexing upgradeable locks since they may block
+        /// indefinitely on the held connection (which would prevent other locks on that connection from releasing) during an upgrade
+        /// operation.
+        /// </summary>
+        bool IsUpgradeable { get; }
+
+        /// <summary>
+        /// Attempts to acquire the lock, returning either null for failure or a non-null state "cookie" on success
+        /// </summary>
+        TLockCookie? TryAcquire(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> resourceNames, int timeoutMillis);
+
+        void Release(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> resourceNames, TLockCookie lockCookie);
+    }
+}

--- a/DistributedLock/Sql/InternalLocks/ExternalConnectionOrTransactionDistributedLocks.cs
+++ b/DistributedLock/Sql/InternalLocks/ExternalConnectionOrTransactionDistributedLocks.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace Medallion.Threading.Sql
+{
+    internal sealed class ExternalConnectionOrTransactionSqlDistributedLocks : IInternalSqlDistributedLocks
+    {
+        private readonly IEnumerable<string> lockNames;
+        private readonly ConnectionOrTransaction connectionOrTransaction;
+
+        public ExternalConnectionOrTransactionSqlDistributedLocks(IEnumerable<string> lockNames, ConnectionOrTransaction connectionOrTransaction)
+        {
+            this.lockNames = lockNames;
+            this.connectionOrTransaction = connectionOrTransaction;
+        }
+
+        public IDisposable? TryAcquire<TLockCookie>(int timeoutMillis, ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, IDisposable? contextHandle)
+            where TLockCookie : class
+        {
+            this.CheckConnection();
+
+            var lockCookie = strategy.TryAcquire(this.connectionOrTransaction, this.lockNames, timeoutMillis);
+            return this.CreateHandle(strategy, lockCookie);
+        }
+
+        private void CheckConnection()
+        {
+            var connection = this.connectionOrTransaction.Connection;
+            if (connection == null) { throw new InvalidOperationException("The transaction had been disposed"); }
+            else if (connection.State != ConnectionState.Open) { throw new InvalidOperationException("The connection is not open"); }
+        }
+
+        private IDisposable? CreateHandle<TLockCookie>(ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, TLockCookie? lockCookie) where TLockCookie : class
+        {
+            if (lockCookie == null) { return null; }
+
+            return new ReleaseAction(() =>
+            {
+                if (this.connectionOrTransaction.Connection?.IsClosedOrBroken() ?? true)
+                {
+                    // lost the connection or transaction disposed, so the lock was already released
+                    return;
+                }
+
+                strategy.Release(this.connectionOrTransaction, this.lockNames, lockCookie);
+            });
+        }
+    }
+}

--- a/DistributedLock/Sql/InternalLocks/OwnedConnectionSqlDistributedLocks.cs
+++ b/DistributedLock/Sql/InternalLocks/OwnedConnectionSqlDistributedLocks.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+
+// ReSharper disable once CheckNamespace
+namespace Medallion.Threading.Sql
+{
+    internal sealed class OwnedConnectionSqlDistributedLocks : IInternalSqlDistributedLocks
+    {
+        private readonly IEnumerable<string> lockNames;
+        private readonly string connectionString;
+
+        public OwnedConnectionSqlDistributedLocks(IEnumerable<string> lockNames, string connectionString)
+        {
+            this.lockNames = lockNames;
+            this.connectionString = connectionString;
+        }
+
+        public IDisposable? TryAcquire<TLockCookie>(int timeoutMillis, ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, IDisposable? contextHandle)
+            where TLockCookie : class
+        {
+            if (contextHandle != null)
+            {
+                return this.CreateContextLock<TLockCookie>(contextHandle).TryAcquire(timeoutMillis, strategy, contextHandle: null);
+            }
+
+            IDisposable? result = null;
+            var connection = SqlHelpers.CreateConnection(this.connectionString);
+            try
+            {
+                connection.Open();
+                var lockCookie = strategy.TryAcquire(connection, this.lockNames, timeoutMillis);
+                if (lockCookie != null)
+                {
+                    result = new LockScope<TLockCookie>(connection, strategy, this.lockNames, lockCookie);
+                }    
+            }
+            finally
+            {
+                // if we fail to acquire or throw, make sure to clean up the connection
+                if (result == null)
+                {
+                    connection.Dispose();
+                }
+            }
+
+            return result;
+        }
+        
+        private IInternalSqlDistributedLocks CreateContextLock<TLockCookie>(IDisposable contextHandle)
+            where TLockCookie : class
+        {
+            var connection = ((LockScope<TLockCookie>)contextHandle).Connection;
+            if (connection == null) { throw new ObjectDisposedException(nameof(contextHandle), "the provided handle is already disposed"); }
+
+            return new ExternalConnectionOrTransactionSqlDistributedLocks(this.lockNames, connection);
+        }
+        
+        private sealed class LockScope<TLockCookie> : IDisposable
+            where TLockCookie : class
+        {
+            private DbConnection? connection;
+            private readonly IEnumerable<string> lockNames;
+            private ISqlSynchronizationStrategyMultiple<TLockCookie>? strategy;
+            private TLockCookie? lockCookie;
+
+            public LockScope(DbConnection connection, ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, IEnumerable<string> lockNames, TLockCookie lockCookie)
+            {
+                this.connection = connection;
+                this.strategy = strategy;
+                this.lockNames = lockNames;
+                this.lockCookie = lockCookie;
+            }
+
+            public DbConnection? Connection => Volatile.Read(ref this.connection);
+
+            public void Dispose()
+            {
+                var localConnection = Interlocked.Exchange(ref this.connection, null);
+                if (localConnection != null && !localConnection.IsClosedOrBroken())
+                {
+                    ReleaseLock(localConnection, this.strategy!, this.lockNames, this.lockCookie!);
+                    this.strategy = null;
+                    this.lockCookie = null;
+                }
+            }
+
+            private static void ReleaseLock(DbConnection connection, ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, IEnumerable<string> lockNames, TLockCookie lockCookie)
+            {
+                try
+                {
+                    // explicit release is required due to connection pooling. For a pooled connection,
+                    // simply calling Dispose() will not release the lock: it just returns the connection
+                    // to the pool
+                    strategy.Release(connection, lockNames, lockCookie);
+                }
+                finally
+                {
+                    connection.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/DistributedLock/Sql/InternalLocks/OwnedTransactionSqlDistributedLocks.cs
+++ b/DistributedLock/Sql/InternalLocks/OwnedTransactionSqlDistributedLocks.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+
+// ReSharper disable once CheckNamespace
+namespace Medallion.Threading.Sql
+{
+    internal sealed class OwnedTransactionSqlDistributedLocks : IInternalSqlDistributedLocks
+    {
+        private readonly IEnumerable<string> lockNames;
+        private readonly string connectionString;
+
+        public OwnedTransactionSqlDistributedLocks(IEnumerable<string> lockNames, string connectionString)
+        {
+            this.lockNames = lockNames;
+            this.connectionString = connectionString;
+        }
+
+        public IDisposable? TryAcquire<TLockCookie>(int timeoutMillis, ISqlSynchronizationStrategyMultiple<TLockCookie> strategy, IDisposable? contextHandle)
+            where TLockCookie : class
+        {
+            if (contextHandle != null)
+            {
+                return this.CreateContextLock(contextHandle).TryAcquire(timeoutMillis, strategy, contextHandle: null);
+            }
+
+            IDisposable? result = null;
+            var connection = SqlHelpers.CreateConnection(this.connectionString);
+            DbTransaction? transaction = null;
+            try
+            {
+                connection.Open();
+                // when creating a transaction, the isolation level doesn't matter, since we're using sp_getapplock
+                transaction = connection.BeginTransaction();
+                var lockCookie = strategy.TryAcquire(transaction, this.lockNames, timeoutMillis);
+                if (lockCookie != null)
+                {
+                    result = new LockScope(transaction);
+                }
+            }
+            finally
+            {
+                // if we fail to acquire or throw, make sure to clean up
+                if (result == null)
+                {
+                    transaction?.Dispose();
+                    connection.Dispose();
+                }
+            }
+
+            return result;
+        }
+        
+        private IInternalSqlDistributedLocks CreateContextLock(IDisposable contextHandle)
+        {
+            var transaction = ((LockScope)contextHandle).Transaction;
+            if (transaction == null) { throw new ObjectDisposedException(nameof(contextHandle), "the provided handle is already disposed"); }
+
+            return new ExternalConnectionOrTransactionSqlDistributedLocks(this.lockNames, transaction);
+        }
+        
+        private sealed class LockScope : IDisposable
+        {
+            private DbTransaction? transaction;
+
+            public LockScope(DbTransaction transaction)
+            {
+                this.transaction = transaction;
+            }
+
+            public DbTransaction? Transaction => Volatile.Read(ref this.transaction);
+
+            public void Dispose()
+            {
+                var localTransaction = Interlocked.Exchange(ref this.transaction, null);
+                if (localTransaction != null)
+                {
+                    var connection = localTransaction.Connection;
+                    localTransaction.Dispose(); // first end the transaction to release the lock
+                    connection.Dispose(); // then close the connection (returns it to the pool)
+                }
+            }
+        }
+    }
+}

--- a/DistributedLock/Sql/SqlApplicationLocks.cs
+++ b/DistributedLock/Sql/SqlApplicationLocks.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Medallion.Threading.Sql
+{
+    internal sealed class SqlApplicationLocks : ISqlSynchronizationStrategyMultiple<object>
+    {
+        public const int TimeoutExitCode = -1;
+
+        public static readonly SqlApplicationLocks SharedLock = new SqlApplicationLocks(Mode.Shared),
+            UpdateLock = new SqlApplicationLocks(Mode.Update),
+            ExclusiveLock = new SqlApplicationLocks(Mode.Exclusive);
+
+        private static readonly object Cookie = new object();
+        private readonly Mode mode;
+
+        private SqlApplicationLocks(Mode mode)
+        {
+            this.mode = mode;
+        }
+
+        bool ISqlSynchronizationStrategyMultiple<object>.IsUpgradeable => this.mode == Mode.Update;
+
+        object? ISqlSynchronizationStrategyMultiple<object>.TryAcquire(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> resourceNames, int timeoutMillis)
+        {
+            return ExecuteAcquireCommand(connectionOrTransaction, resourceNames, timeoutMillis, this.mode) ? Cookie : null;
+        }
+
+        void ISqlSynchronizationStrategyMultiple<object>.Release(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> resourceNames, object lockCookie)
+        {
+            ExecuteReleaseCommand(connectionOrTransaction, resourceNames);
+        }
+
+        private static bool ExecuteAcquireCommand(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> lockNames, int timeoutMillis, Mode mode)
+        {
+            using var command = CreateAcquireCommand(connectionOrTransaction, lockNames, timeoutMillis, mode);
+            var returnValue = (int)command.ExecuteScalar();
+            return ParseExitCode(returnValue);
+        }
+
+        private static void ExecuteReleaseCommand(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> lockNames)
+        {
+            using var command = CreateReleaseCommand(connectionOrTransaction, lockNames);
+            var result = (int)command.ExecuteScalar();
+            ParseExitCode(result);
+        }
+
+        private static IDbCommand CreateAcquireCommand(
+            ConnectionOrTransaction connectionOrTransaction, 
+            IEnumerable<string> lockNames, 
+            int timeoutMillis, 
+            Mode mode)
+        {
+            if (lockNames == null)
+                throw new NullReferenceException(nameof(lockNames));
+            var names = string.Join(",", lockNames);
+            var command = connectionOrTransaction.Connection!.CreateCommand();
+            command.Transaction = connectionOrTransaction.Transaction;
+            command.CommandText = @"
+                BEGIN
+                    DECLARE @lockReturnCodes table (
+                        resourceName nvarchar(255),
+                        code int
+                    );
+                    DECLARE @startLocation int = 1;
+                    DECLARE @result int;
+                    DECLARE @cmd nvarchar(max)
+                    
+                    BEGIN TRY
+                        WHILE (@startLocation >= 1) 
+                        BEGIN
+                            DECLARE @resourceName nvarchar(255);
+                            DECLARE @commaPos int = CHARINDEX(',', @ResourceNames, @startLocation);
+                            IF (@commaPos > 0)
+                                SET @resourceName = SUBSTRING(@resourceNames, @startLocation, @commaPos - @startLocation);
+                            ELSE 
+                            BEGIN
+                                SET @resourceName = SUBSTRING(@resourceNames, @startLocation, LEN(@resourceNames) - @startLocation + 1);
+                                SET @commapos = -2; -- This will cause break out of loop after execute command with the remainder of the string
+                            END;
+                            EXEC @result = dbo.sp_getapplock @Resource=@resourceName, @LockMode=@LockMode, @LockOwner=@LockOwner, @LockTimeout=@LockTimeout;
+                            IF (@result < 0)
+                                THROW 50001, 'Acquiring lock failed', 0; -- All or nothing
+                            INSERT INTO @lockReturnCodes VALUES(@resourceName, @result);
+                            SET @startLocation = @commapos + 1;
+                        END
+                    END TRY
+                    BEGIN CATCH
+                        -- Let's release all acquired locks on any error or on the first lock we failed to acquire
+                        SET @cmd = '';
+                        SELECT @cmd = @cmd + 'EXEC dbo.sp_releaseapplock @Resource=''' + resourceName 
+                            + ''', @LockOwner=''' + @LockOwner + ''';'
+                        FROM @lockReturnCodes;
+                        EXEC sp_executesql @cmd;
+                    END CATCH
+                    SELECT @result
+                END";
+            command.CommandType = CommandType.Text;
+
+            command.Parameters.Add(command.CreateParameter("LockOwner", command.Transaction != null ? "Transaction" : "Session"));
+            command.Parameters.Add(command.CreateParameter("LockMode", GetModeString(mode)));
+            command.Parameters.Add(command.CreateParameter("LockTimeout", timeoutMillis));
+            command.Parameters.Add(command.CreateParameter("ResourceNames", names));
+            
+            command.CommandTimeout = timeoutMillis >= 0
+                  // command timeout is in seconds. We always wait at least the lock timeout plus a buffer 
+                  ? (timeoutMillis / 1000) + 30
+                  // otherwise timeout is infinite so we use the infinite timeout of 0
+                  // (see https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlcommand.commandtimeout%28v=vs.110%29.aspx)
+                  : 0;
+
+            return command;
+        }
+
+        private static IDbCommand CreateReleaseCommand(ConnectionOrTransaction connectionOrTransaction, IEnumerable<string> lockNames)
+        {
+            if (lockNames == null)
+                throw new NullReferenceException(nameof(lockNames));
+            var names = string.Join(",", lockNames);
+            var command = connectionOrTransaction.Connection!.CreateCommand();
+            command.Transaction = connectionOrTransaction.Transaction;
+            command.CommandText = @"
+                BEGIN
+                    DECLARE @startLocation int = 1;
+                    DECLARE @result int = 1;
+                    DECLARE @tmpResult int;
+                    
+                    WHILE (@startLocation >= 1) 
+                    BEGIN
+                        DECLARE @resourceName nvarchar(255);
+                        DECLARE @commaPos int = CHARINDEX(',', @ResourceNames, @startLocation);
+                        IF (@commaPos > 0)
+                            SET @resourceName = SUBSTRING(@resourceNames, @startLocation, @commaPos - @startLocation);			
+                        ELSE 
+                        BEGIN
+                            SET @resourceName = SUBSTRING(@resourceNames, @startLocation, LEN(@resourceNames) - @startLocation + 1);
+                            SET @commapos = -2; -- This will cause break out of loop after execute command with the remainder of the string
+                        END;
+
+                        EXEC @result = dbo.sp_releaseapplock @Resource=@resourceName, @LockOwner=@LockOwner;
+
+                        IF (@tmpResult < @result)
+                            SET @result = @tmpResult;
+                        SET @startLocation = @commaPos + 1;
+                    END	
+                    SELECT @result
+                END";
+            command.CommandType = CommandType.Text;
+            command.Parameters.Add(command.CreateParameter("ResourceNames", names));
+            command.Parameters.Add(command.CreateParameter("LockOwner", command.Transaction != null ? "Transaction" : "Session"));
+            
+            return command;
+        }
+
+        public static bool ParseExitCode(int exitCode)
+        {
+            // sp_getapplock exit codes documented at
+            // https://msdn.microsoft.com/en-us/library/ms189823.aspx
+
+            switch (exitCode)
+            {
+                case 0:
+                case 1:
+                    return true;
+
+                case TimeoutExitCode:
+                    return false;
+
+                case -2: // canceled
+                    throw new OperationCanceledException(GetErrorMessage(exitCode, "canceled"));
+                case -3: // deadlock
+                    throw new DeadlockException(GetErrorMessage(exitCode, "deadlock"));
+                case -999: // parameter / unknown
+                    throw new ArgumentException(GetErrorMessage(exitCode, "parameter validation or other error"));
+
+                default:
+                    if (exitCode <= 0)
+                        throw new InvalidOperationException(GetErrorMessage(exitCode, "unknown"));
+                    return true; // unknown success code
+            }
+        }
+
+        private static string GetErrorMessage(int exitCode, string type) => $"The request for the distribute lock failed with exit code {exitCode} ({type})";
+
+        private static string GetModeString(Mode mode) => mode switch
+        {
+            Mode.Shared => "Shared",
+            Mode.Update => "Update",
+            Mode.Exclusive => "Exclusive",
+            _ => throw new ArgumentException(nameof(mode)),
+        };
+
+        private enum Mode
+        {
+            Shared,
+            Update,
+            Exclusive,
+        }
+    }
+}

--- a/DistributedLock/Sql/SqlApplicationLocks.cs
+++ b/DistributedLock/Sql/SqlApplicationLocks.cs
@@ -77,7 +77,7 @@ namespace Medallion.Threading.Sql
                             ELSE 
                             BEGIN
                                 SET @resourceName = SUBSTRING(@resourceNames, @startLocation, LEN(@resourceNames) - @startLocation + 1);
-                                SET @commapos = -2; -- This will cause break out of loop after execute command with the remainder of the string
+                                SET @commapos = -1; -- This will cause break out of loop after execute command with the remainder of the string
                             END;
                             EXEC @result = dbo.sp_getapplock @Resource=@resourceName, @LockMode=@LockMode, @LockOwner=@LockOwner, @LockTimeout=@LockTimeout;
                             IF (@result < 0)
@@ -135,7 +135,7 @@ namespace Medallion.Threading.Sql
                         ELSE 
                         BEGIN
                             SET @resourceName = SUBSTRING(@resourceNames, @startLocation, LEN(@resourceNames) - @startLocation + 1);
-                            SET @commapos = -2; -- This will cause break out of loop after execute command with the remainder of the string
+                            SET @commapos = -1; -- This will cause break out of loop after execute command with the remainder of the string
                         END;
 
                         EXEC @result = dbo.sp_releaseapplock @Resource=@resourceName, @LockOwner=@LockOwner;

--- a/DistributedLock/Sql/SqlDistributedLocks.cs
+++ b/DistributedLock/Sql/SqlDistributedLocks.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Medallion.Threading.Sql
+{
+    /// <summary>
+    /// Implements a distributed lock using a SQL server application lock
+    /// (see https://msdn.microsoft.com/en-us/library/ms189823.aspx)
+    /// </summary>
+    [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
+    public sealed class SqlDistributedLocks : IDistributedLock
+    {
+        private readonly IInternalSqlDistributedLocks internalLocks;
+
+        /// <summary>
+        /// Creates a lock with name <paramref name="lockNames"/>, using the given
+        /// <paramref name="connectionString"/> to connect to the database.
+        /// 
+        /// Uses <see cref="SqlDistributedLockConnectionStrategy.Default"/>
+        /// </summary>
+        public SqlDistributedLocks(IEnumerable<string> lockNames, string connectionString)
+            : this(lockNames, connectionString, SqlDistributedLockConnectionStrategy.Default)
+        {
+        }
+
+        /// <summary>
+        /// Creates a lock with name <paramref name="lockNames"/>, using the given
+        /// <paramref name="connectionString"/> to connect to the database via the strategy
+        /// specified by <paramref name="connectionStrategy"/>
+        /// </summary>
+        public SqlDistributedLocks(IEnumerable<string> lockNames, string connectionString, SqlDistributedLockConnectionStrategy connectionStrategy)
+            : this(lockNames, CreateInternalLock(lockNames, connectionString, connectionStrategy))
+        {
+            if (string.IsNullOrEmpty(connectionString))
+                throw new ArgumentNullException("connectionString");
+        }
+
+        /// <summary>
+        /// Creates a lock with name <paramref name="lockNames"/> which, when acquired,
+        /// will be scoped to the given <paramref name="connection"/>. The <paramref name="connection"/> is
+        /// assumed to be externally managed: the <see cref="SqlDistributedLock"/> will not attempt to open,
+        /// close, or dispose it
+        /// </summary>
+        public SqlDistributedLocks(IEnumerable<string> lockNames, DbConnection connection)
+            : this(lockNames, (IDbConnection)connection)
+        {
+        }
+
+        /// <summary>
+        /// Creates a lock with name <paramref name="lockNames"/> which, when acquired,
+        /// will be scoped to the given <paramref name="transaction"/>. The <paramref name="transaction"/> and its
+        /// <see cref="DbTransaction.Connection"/> are assumed to be externally managed: the <see cref="SqlDistributedLock"/> will 
+        /// not attempt to open, close, commit, roll back, or dispose them
+        /// </summary>
+        public SqlDistributedLocks(IEnumerable<string> lockNames, DbTransaction transaction)
+            : this(lockNames, (IDbTransaction)transaction)
+        {
+        }
+
+        /// <summary>
+        /// Creates a lock with names <paramref name="lockNames"/> which, when acquired,
+        /// will be scoped to the given <paramref name="connection"/>. The <paramref name="connection"/> is
+        /// assumed to be externally managed: the <see cref="SqlDistributedLock"/> will not attempt to open,
+        /// close, or dispose it
+        /// </summary>
+        public SqlDistributedLocks(IEnumerable<string> lockNames, IDbConnection connection)
+            : this(lockNames, new ExternalConnectionOrTransactionSqlDistributedLocks(lockNames, new ConnectionOrTransaction(connection ?? throw new ArgumentNullException(nameof(connection)))))
+        {
+        }
+
+        /// <summary>
+        /// Creates a lock with name <paramref name="lockNames"/> which, when acquired,
+        /// will be scoped to the given <paramref name="transaction"/>. The <paramref name="transaction"/> and its
+        /// <see cref="DbTransaction.Connection"/> are assumed to be externally managed: the <see cref="SqlDistributedLock"/> will 
+        /// not attempt to open, close, commit, roll back, or dispose them
+        /// </summary>
+        public SqlDistributedLocks(IEnumerable<string> lockNames, IDbTransaction transaction)
+            : this(lockNames, new ExternalConnectionOrTransactionSqlDistributedLocks(lockNames, new ConnectionOrTransaction(transaction ?? throw new ArgumentNullException(nameof(transaction)))))
+        {
+        }
+
+        private SqlDistributedLocks(IEnumerable<string> lockNames, IInternalSqlDistributedLocks internalLocks)
+        {
+            if (lockNames == null)
+                throw new ArgumentNullException(nameof(lockNames));
+            if (lockNames.Any(lck => lck.Length > MaxLockNameLength))
+                throw new FormatException("lockName: must be at most " + MaxLockNameLength + " characters");
+
+            this.internalLocks = internalLocks;
+        }
+
+        #region ---- Public API ----
+        /// <summary>
+        /// Attempts to acquire the lock synchronously. Usage:
+        /// <code>
+        ///     using (var handle = myLock.TryAcquire(...))
+        ///     {
+        ///         if (handle != null) { /* we have the lock! */ }
+        ///     }
+        ///     // dispose releases the lock if we took it
+        /// </code>
+        /// </summary>
+        /// <param name="timeout">How long to wait before giving up on acquiring the lock. Defaults to 0</param>
+        /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+        /// <returns>An <see cref="IDisposable"/> "handle" which can be used to release the lock, or null if the lock was not taken</returns>
+        public IDisposable? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            return cancellationToken.CanBeCanceled
+                // use the async version since that supports cancellation
+                ? DistributedLockHelpers.TryAcquireWithAsyncCancellation(this, timeout, cancellationToken)
+                // synchronous mode
+                : this.internalLocks.TryAcquire(timeout.ToInt32Timeout(), SqlApplicationLocks.ExclusiveLock, contextHandle: null);
+        }
+
+        /// <summary>
+        /// Acquires the lock synchronously, failing with <see cref="TimeoutException"/> if the wait times out
+        /// <code>
+        ///     using (myLock.Acquire(...))
+        ///     {
+        ///         // we have the lock
+        ///     }
+        ///     // dispose releases the lock
+        /// </code>
+        /// </summary>
+        /// <param name="timeout">How long to wait before giving up on acquiring the lock. Defaults to <see cref="Timeout.InfiniteTimeSpan"/></param>
+        /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+        /// <returns>An <see cref="IDisposable"/> "handle" which can be used to release the lock</returns>
+        public IDisposable Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return DistributedLockHelpers.Acquire(this, timeout, cancellationToken);
+        }
+
+        public Task<IDisposable?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Acquires the lock asynchronously, failing with <see cref="TimeoutException"/> if the wait times out
+        /// <code>
+        ///     using (await myLock.AcquireAsync(...))
+        ///     {
+        ///         // we have the lock
+        ///     }
+        ///     // dispose releases the lock
+        /// </code>
+        /// </summary>
+        /// <param name="timeout">How long to wait before giving up on acquiring the lock. Defaults to <see cref="Timeout.InfiniteTimeSpan"/></param>
+        /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+        /// <returns>An <see cref="IDisposable"/> "handle" which can be used to release the lock</returns>
+        public Task<IDisposable> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return DistributedLockHelpers.AcquireAsync(this, timeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// The maximum allowed length for lock names. See https://msdn.microsoft.com/en-us/library/ms189823.aspx
+        /// </summary>
+        public static int MaxLockNameLength => 255;
+
+        /// <summary>
+        /// Given <paramref name="baseLockName"/>, constructs a lock name which is safe for use with <see cref="SqlDistributedLock"/>
+        /// </summary>
+        public static string GetSafeLockName(string baseLockName)
+        {
+            return DistributedLockHelpers.ToSafeLockName(baseLockName, MaxLockNameLength, s => s);
+        }
+        #endregion
+
+        internal static IInternalSqlDistributedLocks CreateInternalLock(IEnumerable<string> lockNames, string connectionString, SqlDistributedLockConnectionStrategy connectionStrategy)
+        {
+            switch (connectionStrategy) 
+            {
+                case SqlDistributedLockConnectionStrategy.Default:
+                case SqlDistributedLockConnectionStrategy.Connection:
+                    return new OwnedConnectionSqlDistributedLocks(lockNames, connectionString: connectionString);
+                case SqlDistributedLockConnectionStrategy.Transaction:
+                    return new OwnedTransactionSqlDistributedLocks(lockNames, connectionString: connectionString);
+                /*case SqlDistributedLockConnectionStrategy.OptimisticConnectionMultiplexing:
+                    return new OptimisticConnectionMultiplexingSqlDistributedLock(lockNames, connectionString: connectionString);
+                case SqlDistributedLockConnectionStrategy.Azure:
+                    return new AzureSqlDistributedLock(lockNames, connectionString: connectionString);*/
+                default:
+                    throw new ArgumentException(nameof(connectionStrategy));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull requests allows the user to acquire locks on multiple resources on one call.
The code ain't pretty. I tried not to modify the existing code but rather there's a new set of files that operate with an Enumerable<string> for the lockNames and there's a new set of interfaces and classes to handle this.

I think it could be generalized to keep the code more compact.

I didn't want to delve into Semaphores either as the code is significantly more complicated on the T-SQL side.

And finally, the code has no support for the async methods.

This PR is not intended to be merged as-is but rather to take the idea if desired and implement in the core library and likely extend to other classes.