### PR TITLE
code optimization

### DIFF
--- a/src/DistributedLock.Azure/BlobClientWrapper.cs
+++ b/src/DistributedLock.Azure/BlobClientWrapper.cs
@@ -25,9 +25,10 @@ internal class BlobClientWrapper
     {
         var conditions = new BlobRequestConditions { LeaseId = leaseId };
         var properties = SyncViaAsync.IsSynchronous
-            ? this._blobClient.GetProperties(conditions, cancellationToken)
-            : await this._blobClient.GetPropertiesAsync(conditions, cancellationToken).ConfigureAwait(false);
-        return properties.Value.Metadata;
+            ? _blobClient.GetProperties(conditions, cancellationToken).AsTask()
+            : _blobClient.GetPropertiesAsync(conditions, cancellationToken);
+        return (await properties.ConfigureAwait(false)).Value.Metadata;
+
     }
 
     public ValueTask CreateIfNotExistsAsync(IDictionary<string, string> metadata, CancellationToken cancellationToken)


### PR DESCRIPTION
In the optimized version, the ValueTask type is used to store the result of the asynchronous operation. By using the AsTask method on the ValueTask, you convert it to a Task when the synchronous path is taken. Then, you can await the Task in both cases, ensuring a consistent usage pattern.

Additionally, I removed the unnecessary this keyword before _blobClient assuming it's not required for the current context. Remember to adjust the code accordingly if necessary.