### PR TITLE
Add build checks for AOT compat

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <!-- Recommended in https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/ -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 </Project>

--- a/src/DistributedLock.Tests/DistributedLock.Tests.csproj
+++ b/src/DistributedLock.Tests/DistributedLock.Tests.csproj
@@ -12,6 +12,8 @@
     <AssemblyOriginatorKeyFile>..\DistributedLock.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
+    <!-- AOT compatibility is not needed in the CI pipeline, so override the value set in Directory.Build.props to use reflections freely -->
+    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The blog post linked in #180 says:
> I would still recommend using the Roslyn analyzers, which means targeting net8.0, because of the convenience and developer productivity they provide.

so I suppose we're going with the first approach of using Roslyn Analyzers?