### PR TITLE
#213 Postgres: Add support for transaction-scoped advisory locks with external transactions - Continuation

### DIFF
--- a/src/DistributedLock.Tests/Tests/Postgres/PostgresDistributedLockExtensionsTest.cs
+++ b/src/DistributedLock.Tests/Tests/Postgres/PostgresDistributedLockExtensionsTest.cs
@@ -109,6 +109,8 @@ internal class PostgresDistributedLockExtensionsTest
 
     
     [Test]
+    // Each lock acquisition creates the same named savepoint; this seems like it would create a conflict
+    // but it actually works fine in Postgres (see https://www.postgresql.org/docs/current/sql-savepoint.html)
     public async Task TestWorksForMultipleLocksUnderTheSameConnectionWithExternalTransaction()
     {
         var key1 = new PostgresAdvisoryLockKey(1);


### PR DESCRIPTION
This PR is a continuation of https://github.com/madelson/DistributedLock/pull/222

Related comments from previous PR: 
https://github.com/madelson/DistributedLock/pull/222/files#r1903151395
https://github.com/madelson/DistributedLock/pull/222/files#r1903151800

Related Issue: https://github.com/madelson/DistributedLock/issues/213
