### PR TITLE
Use CancellationTokenSource.CancelAsync with a compatibility shim

### DIFF
--- a/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
+++ b/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
@@ -329,15 +329,8 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
     private static async Task CancelAndDisposeAsync(
         CancellationTokenSource cancellationTokenSource)
     {
-        try
-        {
-            await cancellationTokenSource.CancelAsync()
-                .ConfigureAwait(false);
-        }
-        finally
-        {
-            cancellationTokenSource.Dispose();
-        }
+        try { await cancellationTokenSource.CancelAsync().ConfigureAwait(false); }
+        finally { cancellationTokenSource.Dispose(); }
     }
 
     private async Task MonitorWorkerLoop()

--- a/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
+++ b/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
@@ -277,11 +277,7 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
             if (isCancel)
             {
                 // cancel in a background thread in case we have hangs or errors
-                Task.Run(() =>
-                {
-                    try { cancellationTokenSource.Cancel(); }
-                    finally { cancellationTokenSource.Dispose(); }
-                });
+                _ = CancelAndDisposeAsync(cancellationTokenSource);
             }
             else
             {
@@ -327,11 +323,21 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
         // it is still safer and easier to reason about not to have that happen. This also ensures
         // that FireStateChangedNoLock() always returns quickly, even if the monitoring loop
         // were to do some synchronous work on the continuation thread.
-        Task.Run(() =>
+        _ = CancelAndDisposeAsync(monitorStateChangedTokenSource);
+    }
+
+    private static async Task CancelAndDisposeAsync(
+        CancellationTokenSource cancellationTokenSource)
+    {
+        try
         {
-            try { monitorStateChangedTokenSource.Cancel(); }
-            finally { monitorStateChangedTokenSource.Dispose(); }
-        });
+            await cancellationTokenSource.CancelAsync()
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            cancellationTokenSource.Dispose();
+        }
     }
 
     private async Task MonitorWorkerLoop()

--- a/src/DistributedLock.Core/Internal/Helpers.cs
+++ b/src/DistributedLock.Core/Internal/Helpers.cs
@@ -106,6 +106,14 @@ static class Helpers
         value = nullable.GetValueOrDefault();
         return nullable.HasValue;
     }
+
+#if !NET8_0_OR_GREATER
+    public static Task CancelAsync(
+        this CancellationTokenSource cancellationTokenSource)
+    {
+        return Task.Run(cancellationTokenSource.Cancel);
+    }
+#endif
 }
 
 /// <summary>

--- a/src/DistributedLock.Core/Internal/LeaseMonitor.cs
+++ b/src/DistributedLock.Core/Internal/LeaseMonitor.cs
@@ -107,7 +107,7 @@ internal
         }
 
         // offload cancel to a background thread to avoid hangs or errors
-        void OnHandleLost() => monitor._cancellationTask = Task.Run(() => monitor._handleLostSource.Cancel());
+        void OnHandleLost() => monitor._cancellationTask = monitor._handleLostSource.CancelAsync();
     }
 
     private async Task<LeaseState> CheckLeaseAsync()

--- a/src/DistributedLock.Tests/Tests/Core/HelpersTest.cs
+++ b/src/DistributedLock.Tests/Tests/Core/HelpersTest.cs
@@ -77,4 +77,33 @@ public class HelpersTest
             await task.TryAwait();
         }
     }
+
+    [Test]
+    public async Task TestCancelAsyncDoesNotBlockOnCallbacks()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var callbackStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var releaseCallback = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var registration = cts.Token.Register(() =>
+        {
+            callbackStarted.SetResult(true);
+
+            releaseCallback.Task.GetAwaiter().GetResult();
+        });
+
+        var cancellationTask = cts.CancelAsync();
+
+        await callbackStarted.Task;
+
+        Assert.That(cancellationTask.IsCompleted, Is.False);
+
+        releaseCallback.SetResult(true);
+
+        await cancellationTask;
+    }
 }


### PR DESCRIPTION
Fixes #265.

- Adds a `CancellationTokenSource.CancelAsync()` compatibility shim for frameworks older than .NET 8.
- Uses the native `CancelAsync()` implementation on .NET 8.
- Replaces background `Task.Run(() => cts.Cancel())` calls with `CancelAsync()`.
- Adds a test verifying that cancellation does not block on callbacks.

Tested on .NET 8 and .NET Framework 4.7.2.