### PR TITLE
Support passive monitoring of Postgres locks

### DIFF
--- a/docs/DistributedLock.Postgres.md
+++ b/docs/DistributedLock.Postgres.md
@@ -43,10 +43,10 @@ In addition to specifying the `key`, Postgres-based locks allow you to specify e
 
 ### Connection monitoring (`HandleLostToken`)
 
-When `HandleLostToken` is used on a lock backed by a library-owned connection, the library monitors the connection passively using `NpgsqlConnection.WaitAsync`, which uses a blocking socket read that detects connection loss (e.g. a database restart or `pg_terminate_backend`) as soon as the socket breaks, without executing any query. The monitored session therefore shows as `idle` in `pg_stat_activity`.
+When `HandleLostToken` is used on a lock backed by a library-owned connection, the library monitors the connection passively using `NpgsqlConnection.WaitAsync`, which uses a blocking socket read that detects connection loss (e.g. a database restart or `pg_terminate_backend`) as soon as the socket breaks, without executing any query. A cheap keepalive query is executed once per passive wait, which happens every `KeepaliveCadence` or every minute, whichever is shorter. Between keepalives the monitored session shows as `idle` in `pg_stat_activity`.
 
 Two things to be aware of:
-- Because the monitored session is idle, server-side idle-session reapers (`idle_session_timeout`, `idle_in_transaction_session_timeout`, or aggressive gateways) can kill it. If any of these are in play, set `KeepaliveCadence`, as when monitoring is active, the keepalive query will be interleaved with the passive wait.
+- Because the monitored session is idle between keepalives, server-side idle-session reapers (`idle_session_timeout`, `idle_in_transaction_session_timeout`, or aggressive gateways) configured with a timeout under one minute can kill it. If any of these are in play, set `KeepaliveCadence` below the reaper timeout.
 - If the connection string enables Npgsql `Multiplexing` (where `Wait` is unsupported) or Npgsql `KeepAlive` (where interrupting `Wait` is not safe), monitoring falls back to parking a `pg_sleep` query on the connection, which shows as an active long-running query.
 
 ## Options

--- a/docs/DistributedLock.Postgres.md
+++ b/docs/DistributedLock.Postgres.md
@@ -41,6 +41,14 @@ Under the hood, [Postgres advisory locks can be based on either one 64-bit integ
 
 In addition to specifying the `key`, Postgres-based locks allow you to specify either a `connectionString`, an `IDbConnection`, or a `DbDataSource` as a means of connecting to the database. In most cases, using a `connectionString` is preferred because it allows for the library to efficiently multiplex connections under the hood and, in the case of `IDbConnection`, eliminates the risk that the passed-in `IDbConnection` gets used in a way that disrupts the locking process. **NOTE that since `IDbConnection` objects are not thread-safe, lock objects constructed with them can only be used by one thread at a time.**
 
+### Connection monitoring (`HandleLostToken`)
+
+When `HandleLostToken` is used on a lock backed by a library-owned connection, the library monitors the connection passively using `NpgsqlConnection.WaitAsync`, which uses a blocking socket read that detects connection loss (e.g. a database restart or `pg_terminate_backend`) as soon as the socket breaks, without executing any query. The monitored session therefore shows as `idle` in `pg_stat_activity`.
+
+Two things to be aware of:
+- Because the monitored session is idle, server-side idle-session reapers (`idle_session_timeout`, `idle_in_transaction_session_timeout`, or aggressive gateways) can kill it. If any of these are in play, set `KeepaliveCadence`, as when monitoring is active, the keepalive query will be interleaved with the passive wait.
+- If the connection string enables Npgsql `Multiplexing` (where `Wait` is unsupported) or Npgsql `KeepAlive` (where interrupting `Wait` is not safe), monitoring falls back to parking a `pg_sleep` query on the connection, which shows as an active long-running query.
+
 ## Options
 
 In addition to specifying the `key`, several tuning options are available for `connectionString`-based locks:

--- a/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
+++ b/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
@@ -357,24 +357,48 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
             stateChangedToken = this._monitorStateChangedTokenSource!.Token;
         }
 
-        return await (isMonitoring ? this.DoMonitoringAsync(stateChangedToken) : this.DoKeepaliveAsync(keepaliveCadence, stateChangedToken)).ConfigureAwait(false);
+        return await (isMonitoring ? this.DoMonitoringAsync(keepaliveCadence, stateChangedToken) : this.DoKeepaliveAsync(keepaliveCadence, stateChangedToken)).ConfigureAwait(false);
     }
 
-    private async Task<bool> DoMonitoringAsync(CancellationToken cancellationToken)
+    private async Task<bool> DoMonitoringAsync(TimeoutValue keepaliveCadence, CancellationToken cancellationToken)
     {
+        // 1-min increments is kind of an arbitrary choice. We want to avoid this being too short since each time
+        // we "come up to breathe" that's a waste of resources. We also want to avoid this being too long since
+        // in case people have some kind of monitoring set up for hanging queries. For passive monitoring, coming
+        // up to breathe also re-resolves the weak connection reference so that this loop never roots an
+        // abandoned connection for long.
+        var monitoringCadence = TimeSpan.FromMinutes(1);
+
         if (!this._weakConnection.TryGetTarget(out var connection)) { return false; }
 
         // don't pass token here: this should finish quickly and we don't want to throw
         using var _ = await this._connectionLock.AcquireAsync(CancellationToken.None).ConfigureAwait(false);
 
-        // 1-min increments is kind of an arbitrary choice. We want to avoid this being too short since each time
-        // we "come up to breathe" that's a waste of resources. We also want to avoid this being too long since
-        // in case people have some kind of monitoring set up for hanging queries
-        await connection.SleepAsync(
-                sleepTime: TimeSpan.FromMinutes(1),
-                cancellationToken: cancellationToken,
-                executor: (command, token) => command.ExecuteNonQueryAsync(token, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true)
-            ).TryAwait();
+        if (connection.SupportsPassiveMonitoring)
+        {
+            var maxWaitTime = !keepaliveCadence.IsInfinite && keepaliveCadence.TimeSpan < monitoringCadence
+                ? keepaliveCadence.TimeSpan
+                : monitoringCadence;
+
+            bool timedOut;
+            try { timedOut = await connection.PassiveMonitorAsync(maxWaitTime, cancellationToken).ConfigureAwait(false); }
+            // cancellation (the connection is wanted for a real query) or connection loss, loop around and re-evaluate state
+            catch { return true; }
+
+            // use the keepalive cadence to prevent idle session killing 
+            if (timedOut && !keepaliveCadence.IsInfinite && !cancellationToken.IsCancellationRequested)
+            {
+                await ExecuteKeepaliveQueryAsync(connection).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            await connection.SleepAsync(
+                    sleepTime: monitoringCadence,
+                    cancellationToken: cancellationToken,
+                    executor: (command, token) => command.ExecuteNonQueryAsync(token, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true)
+                ).TryAwait();
+        }
 
         return true;
     }
@@ -393,14 +417,19 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
         using var connectionLockHandle = await this._connectionLock.TryAcquireAsync(TimeSpan.Zero, CancellationToken.None).ConfigureAwait(false);
         if (connectionLockHandle != null)
         {
-            using var command = connection.CreateCommand();
-            command.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
-            // Since this query is very fast and non-blocking, we don't bother trying to cancel it. This avoids having 
-            // to deal with the overhead of throwing exceptions within ExecuteNonQueryAsync()
-            await command.ExecuteNonQueryAsync(CancellationToken.None, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true).AsTask().TryAwait();
+            await ExecuteKeepaliveQueryAsync(connection).ConfigureAwait(false);
         }
 
         return true;
+    }
+
+    private static async Task ExecuteKeepaliveQueryAsync(DatabaseConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
+        // Since this query is very fast and non-blocking, we don't bother trying to cancel it. This avoids having
+        // to deal with the overhead of throwing exceptions within ExecuteNonQueryAsync()
+        await command.ExecuteNonQueryAsync(CancellationToken.None, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true).AsTask().TryAwait();
     }
 
     private sealed class MonitoringHandle(ConnectionMonitor keepaliveHelper, CancellationToken cancellationToken) : IDatabaseConnectionMonitoringHandle

--- a/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
+++ b/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
@@ -362,22 +362,19 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
 
     private async Task<bool> DoMonitoringAsync(TimeoutValue keepaliveCadence, CancellationToken cancellationToken)
     {
-        // 1-min increments is kind of an arbitrary choice. We want to avoid this being too short since each time
-        // we "come up to breathe" that's a waste of resources. We also want to avoid this being too long since
-        // in case people have some kind of monitoring set up for hanging queries. Coming up to breathe also
-        // re-resolves the weak connection reference so that this loop never roots an abandoned connection for long.
-        TimeoutValue monitoringCadence = TimeSpan.FromMinutes(1);
-
         if (!this._weakConnection.TryGetTarget(out var connection)) { return false; }
 
         // don't pass token here: this should finish quickly and we don't want to throw
         using var _ = await this._connectionLock.AcquireAsync(CancellationToken.None).ConfigureAwait(false);
 
-        // on cancellation (the connection is wanted for a real query) or connection loss, loop around and re-evaluate state
-        await connection.MonitorAsync(
-                monitoringCadence,
-                keepaliveCadence,
-                cancellationToken,
+        await connection.SleepAsync(
+                // 1-min increments is kind of an arbitrary choice. We want to avoid this being too short since each time
+                // we "come up to breathe" that's a waste of resources. We also want to avoid this being too long since
+                // in case people have some kind of monitoring set up for hanging queries. Coming up to breathe also
+                // re-resolves the weak connection reference so that this loop never roots an abandoned connection for long.
+                // Capped at keepaliveCadence so that keepalive queries keep firing on cadence while monitoring.
+                sleepTime: (keepaliveCadence.CompareTo(TimeSpan.FromMinutes(1)) < 0 ? keepaliveCadence : TimeSpan.FromMinutes(1)).TimeSpan,
+                cancellationToken: cancellationToken,
                 executor: (command, token) => command.ExecuteNonQueryAsync(token, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true)
             ).TryAwait();
 
@@ -398,7 +395,11 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
         using var connectionLockHandle = await this._connectionLock.TryAcquireAsync(TimeSpan.Zero, CancellationToken.None).ConfigureAwait(false);
         if (connectionLockHandle != null)
         {
-            await connection.ExecuteKeepaliveQueryAsync().ConfigureAwait(false);
+            using var command = connection.CreateCommand();
+            command.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
+            // Since this query is very fast and non-blocking, we don't bother trying to cancel it. This avoids having 
+            // to deal with the overhead of throwing exceptions within ExecuteNonQueryAsync()
+            await command.ExecuteNonQueryAsync(CancellationToken.None, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true).AsTask().TryAwait();
         }
 
         return true;

--- a/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
+++ b/src/DistributedLock.Core/Internal/Data/ConnectionMonitor.cs
@@ -364,41 +364,22 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
     {
         // 1-min increments is kind of an arbitrary choice. We want to avoid this being too short since each time
         // we "come up to breathe" that's a waste of resources. We also want to avoid this being too long since
-        // in case people have some kind of monitoring set up for hanging queries. For passive monitoring, coming
-        // up to breathe also re-resolves the weak connection reference so that this loop never roots an
-        // abandoned connection for long.
-        var monitoringCadence = TimeSpan.FromMinutes(1);
+        // in case people have some kind of monitoring set up for hanging queries. Coming up to breathe also
+        // re-resolves the weak connection reference so that this loop never roots an abandoned connection for long.
+        TimeoutValue monitoringCadence = TimeSpan.FromMinutes(1);
 
         if (!this._weakConnection.TryGetTarget(out var connection)) { return false; }
 
         // don't pass token here: this should finish quickly and we don't want to throw
         using var _ = await this._connectionLock.AcquireAsync(CancellationToken.None).ConfigureAwait(false);
 
-        if (connection.SupportsPassiveMonitoring)
-        {
-            var maxWaitTime = !keepaliveCadence.IsInfinite && keepaliveCadence.TimeSpan < monitoringCadence
-                ? keepaliveCadence.TimeSpan
-                : monitoringCadence;
-
-            bool timedOut;
-            try { timedOut = await connection.PassiveMonitorAsync(maxWaitTime, cancellationToken).ConfigureAwait(false); }
-            // cancellation (the connection is wanted for a real query) or connection loss, loop around and re-evaluate state
-            catch { return true; }
-
-            // use the keepalive cadence to prevent idle session killing 
-            if (timedOut && !keepaliveCadence.IsInfinite && !cancellationToken.IsCancellationRequested)
-            {
-                await ExecuteKeepaliveQueryAsync(connection).ConfigureAwait(false);
-            }
-        }
-        else
-        {
-            await connection.SleepAsync(
-                    sleepTime: monitoringCadence,
-                    cancellationToken: cancellationToken,
-                    executor: (command, token) => command.ExecuteNonQueryAsync(token, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true)
-                ).TryAwait();
-        }
+        // on cancellation (the connection is wanted for a real query) or connection loss, loop around and re-evaluate state
+        await connection.MonitorAsync(
+                monitoringCadence,
+                keepaliveCadence,
+                cancellationToken,
+                executor: (command, token) => command.ExecuteNonQueryAsync(token, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true)
+            ).TryAwait();
 
         return true;
     }
@@ -417,19 +398,10 @@ internal sealed class ConnectionMonitor : IAsyncDisposable
         using var connectionLockHandle = await this._connectionLock.TryAcquireAsync(TimeSpan.Zero, CancellationToken.None).ConfigureAwait(false);
         if (connectionLockHandle != null)
         {
-            await ExecuteKeepaliveQueryAsync(connection).ConfigureAwait(false);
+            await connection.ExecuteKeepaliveQueryAsync().ConfigureAwait(false);
         }
 
         return true;
-    }
-
-    private static async Task ExecuteKeepaliveQueryAsync(DatabaseConnection connection)
-    {
-        using var command = connection.CreateCommand();
-        command.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
-        // Since this query is very fast and non-blocking, we don't bother trying to cancel it. This avoids having
-        // to deal with the overhead of throwing exceptions within ExecuteNonQueryAsync()
-        await command.ExecuteNonQueryAsync(CancellationToken.None, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true).AsTask().TryAwait();
     }
 
     private sealed class MonitoringHandle(ConnectionMonitor keepaliveHelper, CancellationToken cancellationToken) : IDatabaseConnectionMonitoringHandle

--- a/src/DistributedLock.Core/Internal/Data/DatabaseConnection.cs
+++ b/src/DistributedLock.Core/Internal/Data/DatabaseConnection.cs
@@ -171,19 +171,20 @@ internal
     public abstract bool IsCommandCancellationException(Exception exception);
 
     public abstract Task SleepAsync(TimeSpan sleepTime, CancellationToken cancellationToken, Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor);
-
-    /// <summary>
-    /// Whether this connection supports monitoring via <see cref="PassiveMonitorAsync"/> instead of
-    /// parking a long-running sleep query on the connection (<see cref="SleepAsync"/>).
-    /// </summary>
-    public virtual bool SupportsPassiveMonitoring => false;
-
-    /// <summary>
-    /// Passively waits for connection activity/failure without executing a query. Returns true if
-    /// <paramref name="maxWaitTime"/> elapsed with the connection still healthy. Throws
-    /// <see cref="OperationCanceledException"/> on cancellation and a provider exception on connection
-    /// loss (which must also cause the underlying <see cref="DbConnection.StateChange"/> event to fire).
-    /// </summary>
-    public virtual Task<bool> PassiveMonitorAsync(TimeSpan maxWaitTime, CancellationToken cancellationToken) =>
-        throw new NotSupportedException();
+    
+    public virtual Task MonitorAsync(
+        TimeoutValue monitoringCadence,
+        TimeoutValue keepaliveCadence,
+        CancellationToken cancellationToken,
+        Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor) =>
+        this.SleepAsync(monitoringCadence.TimeSpan, cancellationToken, executor);
+    
+    public async Task ExecuteKeepaliveQueryAsync()
+    {
+        using var command = this.CreateCommand();
+        command.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
+        // Since this query is very fast and non-blocking, we don't bother trying to cancel it. This avoids having
+        // to deal with the overhead of throwing exceptions within ExecuteNonQueryAsync()
+        await command.ExecuteNonQueryAsync(CancellationToken.None, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true).AsTask().TryAwait();
+    }
 }

--- a/src/DistributedLock.Core/Internal/Data/DatabaseConnection.cs
+++ b/src/DistributedLock.Core/Internal/Data/DatabaseConnection.cs
@@ -171,4 +171,19 @@ internal
     public abstract bool IsCommandCancellationException(Exception exception);
 
     public abstract Task SleepAsync(TimeSpan sleepTime, CancellationToken cancellationToken, Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor);
+
+    /// <summary>
+    /// Whether this connection supports monitoring via <see cref="PassiveMonitorAsync"/> instead of
+    /// parking a long-running sleep query on the connection (<see cref="SleepAsync"/>).
+    /// </summary>
+    public virtual bool SupportsPassiveMonitoring => false;
+
+    /// <summary>
+    /// Passively waits for connection activity/failure without executing a query. Returns true if
+    /// <paramref name="maxWaitTime"/> elapsed with the connection still healthy. Throws
+    /// <see cref="OperationCanceledException"/> on cancellation and a provider exception on connection
+    /// loss (which must also cause the underlying <see cref="DbConnection.StateChange"/> event to fire).
+    /// </summary>
+    public virtual Task<bool> PassiveMonitorAsync(TimeSpan maxWaitTime, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
 }

--- a/src/DistributedLock.Core/Internal/Data/DatabaseConnection.cs
+++ b/src/DistributedLock.Core/Internal/Data/DatabaseConnection.cs
@@ -171,20 +171,4 @@ internal
     public abstract bool IsCommandCancellationException(Exception exception);
 
     public abstract Task SleepAsync(TimeSpan sleepTime, CancellationToken cancellationToken, Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor);
-    
-    public virtual Task MonitorAsync(
-        TimeoutValue monitoringCadence,
-        TimeoutValue keepaliveCadence,
-        CancellationToken cancellationToken,
-        Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor) =>
-        this.SleepAsync(monitoringCadence.TimeSpan, cancellationToken, executor);
-    
-    public async Task ExecuteKeepaliveQueryAsync()
-    {
-        using var command = this.CreateCommand();
-        command.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
-        // Since this query is very fast and non-blocking, we don't bother trying to cancel it. This avoids having
-        // to deal with the overhead of throwing exceptions within ExecuteNonQueryAsync()
-        await command.ExecuteNonQueryAsync(CancellationToken.None, disallowAsyncCancellation: false, isConnectionMonitoringQuery: true).AsTask().TryAwait();
-    }
 }

--- a/src/DistributedLock.Postgres/PostgresDatabaseConnection.cs
+++ b/src/DistributedLock.Postgres/PostgresDatabaseConnection.cs
@@ -1,19 +1,19 @@
-﻿using Medallion.Threading.Internal;
+using Medallion.Threading.Internal;
 using Medallion.Threading.Internal.Data;
 using Npgsql;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics;
 
 namespace Medallion.Threading.Postgres;
 
 internal sealed class PostgresDatabaseConnection : DatabaseConnection
 {
     /// <summary>
-    /// Set only for connections we own and can therefore run passive monitoring on
-    /// (the monitor never runs background work on externally-owned connections)
+    /// Only safe to use inside <see cref="SleepAsync"/>, where the connection monitor holds the connection lock.
+    /// Non-default only for connections we own (passive monitoring never touches externally-owned connections).
     /// </summary>
-    private readonly NpgsqlConnection? _ownedNpgsqlConnection;
-    private bool? _supportsPassiveMonitoring;
+    private readonly WaitAsyncWrapper _unsafeWaitAsyncWrapper;
 
     public PostgresDatabaseConnection(IDbConnection connection)
         : base(connection, isExternallyOwned: true)
@@ -40,7 +40,7 @@ internal sealed class PostgresDatabaseConnection : DatabaseConnection
     private PostgresDatabaseConnection(DbConnection ownedConnection)
         : base(ownedConnection, isExternallyOwned: false)
     {
-        this._ownedNpgsqlConnection = ownedConnection as NpgsqlConnection;
+        this._unsafeWaitAsyncWrapper = new(ownedConnection);
     }
 
     // see https://www.npgsql.org/doc/prepare.html
@@ -51,44 +51,21 @@ internal sealed class PostgresDatabaseConnection : DatabaseConnection
             // cancellation error code from https://www.postgresql.org/docs/10/errcodes-appendix.html
             && postgresException.SqlState == "57014";
 
-    public override async Task MonitorAsync(
-        TimeoutValue monitoringCadence,
-        TimeoutValue keepaliveCadence,
-        CancellationToken cancellationToken,
-        Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor)
-    {
-        if (!this.SupportsPassiveMonitoring)
-        {
-            await base.MonitorAsync(monitoringCadence, keepaliveCadence, cancellationToken, executor).ConfigureAwait(false);
-            return;
-        }
-
-        // Passively wait for connection activity/failure without executing a query, leaving the
-        // session idle server-side. Cap the wait at the keepalive cadence so the session is never
-        // seen as idle for longer than that.
-        var maxWaitTime = !keepaliveCadence.IsInfinite && keepaliveCadence.CompareTo(monitoringCadence) < 0
-            ? keepaliveCadence
-            : monitoringCadence;
-        await this._ownedNpgsqlConnection!.WaitAsync(maxWaitTime.TimeSpan, cancellationToken).ConfigureAwait(false);
-
-        // the passive wait left the session idle; run the keepalive query to prevent idle session killing
-        if (!keepaliveCadence.IsInfinite && !cancellationToken.IsCancellationRequested)
-        {
-            await this.ExecuteKeepaliveQueryAsync().ConfigureAwait(false);
-        }
-    }
-
-    // NpgsqlConnection.Wait is unsupported with Npgsql multiplexing, and unsafe to cancel when Npgsql
-    // KeepAlive is enabled (cancellation mid-keepalive-exchange breaks the connection) — monitoring
-    // falls back to the pg_sleep query in those cases
-    private bool SupportsPassiveMonitoring =>
-        this._supportsPassiveMonitoring ??=
-            this._ownedNpgsqlConnection != null
-            && new NpgsqlConnectionStringBuilder(this._ownedNpgsqlConnection.ConnectionString) is { Multiplexing: false, KeepAlive: 0 };
-
     public override async Task SleepAsync(TimeSpan sleepTime, CancellationToken cancellationToken, Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor)
     {
         Invariant.Require(sleepTime >= TimeSpan.Zero);
+
+        // Where supported, "sleep" by passively waiting for connection activity/failure without executing a
+        // query. This detects connection loss as soon as the socket breaks rather than when the sleep query
+        // errors, and leaves the session idle server-side.
+        if (await this._unsafeWaitAsyncWrapper.TryWaitAsync(sleepTime, cancellationToken).ConfigureAwait(false))
+        {
+            // the passive wait left the session idle; run a keepalive query to prevent idle session reaping
+            using var keepaliveCommand = this.CreateCommand();
+            keepaliveCommand.SetCommandText("SELECT 0 /* DistributedLock connection keepalive */");
+            await executor(keepaliveCommand, cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
         // if we're in a transaction, we need to establish a savepoint so that we can roll back if we
         // get canceled without the whole transaction being aborted
@@ -118,6 +95,42 @@ internal sealed class PostgresDatabaseConnection : DatabaseConnection
                 rollBackSavePointCommand.SetCommandText("ROLLBACK TO SAVEPOINT " + SavePointName);
                 await executor(rollBackSavePointCommand, CancellationToken.None).ConfigureAwait(false);
             }
+        }
+    }
+
+    /// <summary>
+    /// Exposes only <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/> from the wrapped
+    /// connection, keeping the rest of the (non-thread-safe) connection surface inaccessible.
+    /// </summary>
+    private readonly struct WaitAsyncWrapper(DbConnection dbConnection)
+    {
+        // Null when passive waiting is unsupported: non-Npgsql connection, Npgsql multiplexing (Wait is
+        // unsupported), or Npgsql KeepAlive (cancellation mid-keepalive-exchange breaks the connection)
+        private readonly NpgsqlConnection? _connection =
+            dbConnection is NpgsqlConnection npgsqlConnection
+                && new NpgsqlConnectionStringBuilder(npgsqlConnection.ConnectionString) is { Multiplexing: false, KeepAlive: 0 }
+                ? npgsqlConnection
+                : null;
+
+        public async ValueTask<bool> TryWaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (this._connection is null) { return false; }
+
+            // WaitAsync completes when ANY message arrives (e.g. a notification), not just on timeout,
+            // so loop until the full timeout has elapsed
+            var startTimestamp = Stopwatch.GetTimestamp();
+            var remaining = timeout;
+            while (await this._connection.WaitAsync(remaining, cancellationToken).ConfigureAwait(false))
+            {
+#if NET7_0_OR_GREATER
+                var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+#else
+                var elapsed = TimeSpan.FromSeconds((Stopwatch.GetTimestamp() - startTimestamp) / (double)Stopwatch.Frequency);
+#endif
+                remaining = timeout - elapsed;
+                if (remaining <= TimeSpan.Zero) { break; }
+            }
+            return true;
         }
     }
 }

--- a/src/DistributedLock.Postgres/PostgresDatabaseConnection.cs
+++ b/src/DistributedLock.Postgres/PostgresDatabaseConnection.cs
@@ -51,18 +51,40 @@ internal sealed class PostgresDatabaseConnection : DatabaseConnection
             // cancellation error code from https://www.postgresql.org/docs/10/errcodes-appendix.html
             && postgresException.SqlState == "57014";
 
+    public override async Task MonitorAsync(
+        TimeoutValue monitoringCadence,
+        TimeoutValue keepaliveCadence,
+        CancellationToken cancellationToken,
+        Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor)
+    {
+        if (!this.SupportsPassiveMonitoring)
+        {
+            await base.MonitorAsync(monitoringCadence, keepaliveCadence, cancellationToken, executor).ConfigureAwait(false);
+            return;
+        }
+
+        // Passively wait for connection activity/failure without executing a query, leaving the
+        // session idle server-side. Cap the wait at the keepalive cadence so the session is never
+        // seen as idle for longer than that.
+        var maxWaitTime = !keepaliveCadence.IsInfinite && keepaliveCadence.CompareTo(monitoringCadence) < 0
+            ? keepaliveCadence
+            : monitoringCadence;
+        await this._ownedNpgsqlConnection!.WaitAsync(maxWaitTime.TimeSpan, cancellationToken).ConfigureAwait(false);
+
+        // the passive wait left the session idle; run the keepalive query to prevent idle session killing
+        if (!keepaliveCadence.IsInfinite && !cancellationToken.IsCancellationRequested)
+        {
+            await this.ExecuteKeepaliveQueryAsync().ConfigureAwait(false);
+        }
+    }
+
     // NpgsqlConnection.Wait is unsupported with Npgsql multiplexing, and unsafe to cancel when Npgsql
     // KeepAlive is enabled (cancellation mid-keepalive-exchange breaks the connection) — monitoring
     // falls back to the pg_sleep query in those cases
-    public override bool SupportsPassiveMonitoring =>
+    private bool SupportsPassiveMonitoring =>
         this._supportsPassiveMonitoring ??=
             this._ownedNpgsqlConnection != null
             && new NpgsqlConnectionStringBuilder(this._ownedNpgsqlConnection.ConnectionString) is { Multiplexing: false, KeepAlive: 0 };
-
-    public override async Task<bool> PassiveMonitorAsync(TimeSpan maxWaitTime, CancellationToken cancellationToken) =>
-        // WaitAsync returns true if an async message (e.g. a notification) arrived; we never LISTEN, so
-        // treat that as "still healthy but not a timeout" and let the monitoring loop continue
-        !await this._ownedNpgsqlConnection!.WaitAsync(maxWaitTime, cancellationToken).ConfigureAwait(false);
 
     public override async Task SleepAsync(TimeSpan sleepTime, CancellationToken cancellationToken, Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor)
     {

--- a/src/DistributedLock.Postgres/PostgresDatabaseConnection.cs
+++ b/src/DistributedLock.Postgres/PostgresDatabaseConnection.cs
@@ -2,14 +2,19 @@
 using Medallion.Threading.Internal.Data;
 using Npgsql;
 using System.Data;
-#if NET7_0_OR_GREATER
 using System.Data.Common;
-#endif
 
 namespace Medallion.Threading.Postgres;
 
 internal sealed class PostgresDatabaseConnection : DatabaseConnection
 {
+    /// <summary>
+    /// Set only for connections we own and can therefore run passive monitoring on
+    /// (the monitor never runs background work on externally-owned connections)
+    /// </summary>
+    private readonly NpgsqlConnection? _ownedNpgsqlConnection;
+    private bool? _supportsPassiveMonitoring;
+
     public PostgresDatabaseConnection(IDbConnection connection)
         : base(connection, isExternallyOwned: true)
     {
@@ -22,14 +27,20 @@ internal sealed class PostgresDatabaseConnection : DatabaseConnection
 
 #if NET7_0_OR_GREATER
     public PostgresDatabaseConnection(DbDataSource dbDataSource)
-        : base(dbDataSource.CreateConnection(), isExternallyOwned: false)
+        : this(dbDataSource.CreateConnection())
     {
     }
 #endif
 
     public PostgresDatabaseConnection(string connectionString)
-        : base(new NpgsqlConnection(connectionString), isExternallyOwned: false)
+        : this(new NpgsqlConnection(connectionString))
     {
+    }
+
+    private PostgresDatabaseConnection(DbConnection ownedConnection)
+        : base(ownedConnection, isExternallyOwned: false)
+    {
+        this._ownedNpgsqlConnection = ownedConnection as NpgsqlConnection;
     }
 
     // see https://www.npgsql.org/doc/prepare.html
@@ -39,6 +50,19 @@ internal sealed class PostgresDatabaseConnection : DatabaseConnection
         exception is PostgresException postgresException
             // cancellation error code from https://www.postgresql.org/docs/10/errcodes-appendix.html
             && postgresException.SqlState == "57014";
+
+    // NpgsqlConnection.Wait is unsupported with Npgsql multiplexing, and unsafe to cancel when Npgsql
+    // KeepAlive is enabled (cancellation mid-keepalive-exchange breaks the connection) — monitoring
+    // falls back to the pg_sleep query in those cases
+    public override bool SupportsPassiveMonitoring =>
+        this._supportsPassiveMonitoring ??=
+            this._ownedNpgsqlConnection != null
+            && new NpgsqlConnectionStringBuilder(this._ownedNpgsqlConnection.ConnectionString) is { Multiplexing: false, KeepAlive: 0 };
+
+    public override async Task<bool> PassiveMonitorAsync(TimeSpan maxWaitTime, CancellationToken cancellationToken) =>
+        // WaitAsync returns true if an async message (e.g. a notification) arrived; we never LISTEN, so
+        // treat that as "still healthy but not a timeout" and let the monitoring loop continue
+        !await this._ownedNpgsqlConnection!.WaitAsync(maxWaitTime, cancellationToken).ConfigureAwait(false);
 
     public override async Task SleepAsync(TimeSpan sleepTime, CancellationToken cancellationToken, Func<DatabaseCommand, CancellationToken, ValueTask<int>> executor)
     {

--- a/src/DistributedLock.Tests/Tests/Postgres/PostgresBehaviorTest.cs
+++ b/src/DistributedLock.Tests/Tests/Postgres/PostgresBehaviorTest.cs
@@ -192,6 +192,36 @@ public class PostgresBehaviorTest
     }
 
     /// <summary>
+    /// Demonstrates that <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/> returns true
+    /// as soon as any message (e.g. a notification) arrives, before the timeout elapses. Passive connection
+    /// monitoring accounts for this by looping until its full wait time has elapsed.
+    /// </summary>
+    [Test]
+    public async Task TestWaitAsyncReturnsTrueWhenMessageArrives()
+    {
+        var channelName = $"wait_test_{Guid.NewGuid():N}";
+
+        using var connection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await connection.OpenAsync();
+        using (var listenCommand = connection.CreateCommand())
+        {
+            listenCommand.CommandText = $"LISTEN {channelName}";
+            await listenCommand.ExecuteNonQueryAsync();
+        }
+
+        var waitTask = connection.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        using var notifyingConnection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await notifyingConnection.OpenAsync();
+        using var notifyCommand = notifyingConnection.CreateCommand();
+        notifyCommand.CommandText = $"NOTIFY {channelName}";
+        await notifyCommand.ExecuteNonQueryAsync();
+
+        Assert.That(await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(10))), Is.SameAs(waitTask), "wait should complete when the notification arrives");
+        Assert.That(await waitTask, Is.True);
+    }
+
+    /// <summary>
     /// Demonstrates that a connection killed during <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/>
     /// throws and fires <see cref="System.Data.Common.DbConnection.StateChange"/>, which is what drives
     /// <see cref="IDistributedSynchronizationHandle.HandleLostToken"/> under passive monitoring.

--- a/src/DistributedLock.Tests/Tests/Postgres/PostgresBehaviorTest.cs
+++ b/src/DistributedLock.Tests/Tests/Postgres/PostgresBehaviorTest.cs
@@ -1,4 +1,4 @@
-﻿using Npgsql;
+using Npgsql;
 using NUnit.Framework;
 using System.Data;
 
@@ -135,7 +135,91 @@ public class PostgresBehaviorTest
 
         Assert.That(stateChangedEvent.Wait(TimeSpan.FromSeconds(.1)), Is.False);
 
-        Assert.Throws<NpgsqlException>(() => getPidCommand.ExecuteScalar());
+        // Catch rather than Throws because whether this surfaces as NpgsqlException (broken connection)
+        // or the derived PostgresException (the server's 57P01 error message was read first) is timing-dependent
+        Assert.Catch<NpgsqlException>(() => getPidCommand.ExecuteScalar());
+        Assert.That(stateChangedEvent.Wait(TimeSpan.FromSeconds(5)), Is.True);
+    }
+
+    /// <summary>
+    /// Demonstrates that a timed-out <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/> is
+    /// non-destructive: it returns false and the connection (including an open transaction) remains usable.
+    /// Passive connection monitoring relies on this.
+    /// </summary>
+    [Test]
+    public async Task TestWaitAsyncTimeoutDoesNotBreakConnection()
+    {
+        using var connection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await connection.OpenAsync();
+
+        Assert.That(await connection.WaitAsync(TimeSpan.FromMilliseconds(100), CancellationToken.None), Is.False);
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        (await command.ExecuteScalarAsync()).ShouldEqual(1);
+
+        using (var transaction = connection.BeginTransaction())
+        {
+            Assert.That(await connection.WaitAsync(TimeSpan.FromMilliseconds(100), CancellationToken.None), Is.False);
+
+            // the transaction was not aborted by the timed-out wait
+            command.Transaction = transaction;
+            command.CommandText = "SELECT 2";
+            (await command.ExecuteScalarAsync()).ShouldEqual(2);
+        }
+    }
+
+    /// <summary>
+    /// Demonstrates that canceling <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/> is
+    /// non-destructive: it throws <see cref="OperationCanceledException"/> and the connection remains usable.
+    /// Passive connection monitoring relies on this because the monitor's wait is canceled whenever the
+    /// connection is needed for a real query.
+    /// </summary>
+    [Test]
+    public async Task TestWaitAsyncCancellationDoesNotBreakConnection()
+    {
+        using var connection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await connection.OpenAsync();
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(.5));
+        Assert.CatchAsync<OperationCanceledException>(() => connection.WaitAsync(TimeSpan.FromSeconds(30), cancellationTokenSource.Token));
+
+        Assert.That(connection.State, Is.EqualTo(ConnectionState.Open));
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        (await command.ExecuteScalarAsync()).ShouldEqual(1);
+    }
+
+    /// <summary>
+    /// Demonstrates that a connection killed during <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/>
+    /// throws and fires <see cref="System.Data.Common.DbConnection.StateChange"/>, which is what drives
+    /// <see cref="IDistributedSynchronizationHandle.HandleLostToken"/> under passive monitoring.
+    /// </summary>
+    [Test]
+    public async Task TestWaitAsyncOnKilledConnectionFiresStateChanged()
+    {
+        using var stateChangedEvent = new ManualResetEventSlim(initialState: false);
+
+        using var connection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await connection.OpenAsync();
+        connection.StateChange += (o, e) => stateChangedEvent.Set();
+
+        using var getPidCommand = connection.CreateCommand();
+        getPidCommand.CommandText = "SELECT pg_backend_pid()";
+        var pid = (int)(await getPidCommand.ExecuteScalarAsync())!;
+
+        var waitTask = connection.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        // kill the connection from the back end
+        using var killingConnection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await killingConnection.OpenAsync();
+        using var killCommand = killingConnection.CreateCommand();
+        killCommand.CommandText = $"SELECT pg_terminate_backend({pid})";
+        await killCommand.ExecuteNonQueryAsync();
+
+        Assert.CatchAsync<NpgsqlException>(() => waitTask);
+        Assert.That(connection.State, Is.Not.EqualTo(ConnectionState.Open));
         Assert.That(stateChangedEvent.Wait(TimeSpan.FromSeconds(5)), Is.True);
     }
 

--- a/src/DistributedLock.Tests/Tests/Postgres/PostgresConnectionMonitoringTest.cs
+++ b/src/DistributedLock.Tests/Tests/Postgres/PostgresConnectionMonitoringTest.cs
@@ -1,0 +1,126 @@
+using Medallion.Threading.Postgres;
+using Medallion.Threading.Tests.Data;
+using Npgsql;
+using NUnit.Framework;
+
+namespace Medallion.Threading.Tests.Postgres;
+
+/// <summary>
+/// Tests for passive connection monitoring on Postgres: when <see cref="IDistributedSynchronizationHandle.HandleLostToken"/>
+/// is used on an owned connection, monitoring uses <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/>
+/// (the session stays idle) rather than parking a pg_sleep query on the connection.
+/// </summary>
+public class PostgresConnectionMonitoringTest
+{
+    private readonly TestingPostgresDb _db = new();
+
+    [Test]
+    public async Task TestMonitoringSessionIsIdleWithoutSleepQuery()
+    {
+        var applicationName = UniqueApplicationName();
+        var @lock = CreateLock(applicationName);
+        await using var handle = await @lock.AcquireAsync();
+
+        Assert.That(handle.HandleLostToken.CanBeCanceled, Is.True); // starts monitoring
+
+        // give the monitoring worker time to engage
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        using var connection = new NpgsqlConnection(TestingPostgresDb.DefaultConnectionString);
+        await connection.OpenAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+            SELECT state, query
+            FROM pg_stat_activity
+            WHERE application_name = @applicationName";
+        command.Parameters.AddWithValue("applicationName", applicationName);
+
+        var sessions = new List<(string State, string Query)>();
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                sessions.Add((
+                    reader.IsDBNull(0) ? string.Empty : reader.GetString(0),
+                    reader.IsDBNull(1) ? string.Empty : reader.GetString(1)
+                ));
+            }
+        }
+
+        Assert.That(sessions, Is.Not.Empty);
+        Assert.That(sessions, Has.All.Matches<(string State, string Query)>(s => s.State == "idle"), "monitored sessions should not be running a query");
+        Assert.That(sessions, Has.None.Matches<(string State, string Query)>(s => s.Query.Contains("pg_sleep")), "monitoring should not use pg_sleep");
+    }
+
+    [Test]
+    public async Task TestHandleLostTokenFiresOnKilledConnectionWithPassiveMonitoring()
+    {
+        var applicationName = UniqueApplicationName();
+        var @lock = CreateLock(applicationName);
+        var handle = await @lock.AcquireAsync();
+
+        using var handleLostEvent = new ManualResetEventSlim(initialState: false);
+        using var registration = handle.HandleLostToken.Register(handleLostEvent.Set);
+
+        await this._db.KillSessionsAsync(applicationName, idleSince: null);
+
+        Assert.That(handleLostEvent.Wait(TimeSpan.FromSeconds(10)), Is.True);
+
+        // dispose may throw since the underlying connection is broken
+        try { handle.Dispose(); } catch { }
+    }
+
+    [Test]
+    [NonParallelizable, Retry(5)] // timing-sensitive
+    public async Task TestMonitoringWithKeepaliveCadenceSurvivesIdleSessionKiller()
+    {
+        var applicationName = UniqueApplicationName();
+        var @lock = CreateLock(applicationName, options => options.KeepaliveCadence(TimeSpan.FromSeconds(.05)));
+
+        var handle = await @lock.AcquireAsync();
+        Assert.That(handle.HandleLostToken.CanBeCanceled, Is.True); // monitoring + keepalive cadence => keepalive interleave
+
+        using var idleSessionKiller = new IdleSessionKiller(this._db, applicationName, idleTimeout: TimeSpan.FromSeconds(.5));
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        Assert.That(handle.HandleLostToken.IsCancellationRequested, Is.False);
+        Assert.DoesNotThrow(handle.Dispose);
+    }
+
+    /// <summary>
+    /// Npgsql KeepAlive is incompatible with canceling <see cref="NpgsqlConnection.WaitAsync(TimeSpan, CancellationToken)"/>,
+    /// so monitoring falls back to the pg_sleep query for such connection strings. This verifies the fallback end-to-end.
+    /// </summary>
+    [Test]
+    public async Task TestHandleLostTokenWorksWithNpgsqlKeepAliveFallback()
+    {
+        var applicationName = UniqueApplicationName();
+        var @lock = CreateLock(applicationName, connectionStringOptions: builder => builder.KeepAlive = 1);
+        var handle = await @lock.AcquireAsync();
+
+        using var handleLostEvent = new ManualResetEventSlim(initialState: false);
+        Assert.That(handle.HandleLostToken.CanBeCanceled, Is.True);
+        using var registration = handle.HandleLostToken.Register(handleLostEvent.Set);
+
+        await this._db.KillSessionsAsync(applicationName, idleSince: null);
+
+        Assert.That(handleLostEvent.Wait(TimeSpan.FromSeconds(10)), Is.True);
+
+        // dispose may throw since the underlying connection is broken
+        try { handle.Dispose(); } catch { }
+    }
+
+    private static string UniqueApplicationName() => $"monitoring_test_{Guid.NewGuid():N}";
+
+    private static PostgresDistributedLock CreateLock(
+        string applicationName,
+        Action<PostgresConnectionOptionsBuilder>? options = null,
+        Action<NpgsqlConnectionStringBuilder>? connectionStringOptions = null)
+    {
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(TestingPostgresDb.DefaultConnectionString) { ApplicationName = applicationName };
+        connectionStringOptions?.Invoke(connectionStringBuilder);
+
+        // use a unique lock name since advisory lock keys are global to the database (and some tests retry)
+        return new PostgresDistributedLock(new(Guid.NewGuid().ToString(), allowHashing: true), connectionStringBuilder.ConnectionString, options);
+    }
+}


### PR DESCRIPTION
Hiya, I've used this package quite a lot over the last few years, both in my work as well as open source (I moved [MartenDB](https://martendb.io/) over to it a while ago, and it'll be used within the v1 of [Wallaby](https://wallabycdc.net/)). I find the lock monitoring especially useful and it eliminated an entire class of problems for us, but the `pg_sleep` query causes a few issues:
- Users tend to freak out when they see a long-running query show up in monitoring tools. We've had a number of Marten users complain about the "load" that monitoring tools are reporting despite `pg_sleep` not doing anything, to the point that we provided an opt-out on monitoring just to eliminate the noise. This gets flagged by automated problem finders too, like Datadog's DBM and RDS Performance Insights
- The sleeping query skews query performance stats as your average query time goes through the roof and you have to filter it out whenever you're looking at metrics or trying to setup alarms.

This PR adds a passive approach that waits for the socket to break instead. In monitoring tools this will simply show up as an idle connection. This is codepath is enabled by default, but is unsupported when:
- Npgsql Multiplexing is enabled (not very important as multiplexing is getting removed from npgsql in v11)
- KeepAlive is enabled on the connection string

If either case is true, it'll fall back to using the pg_sleep path.